### PR TITLE
Create license workflow

### DIFF
--- a/leaseslicensing/components/approvals/api.py
+++ b/leaseslicensing/components/approvals/api.py
@@ -328,9 +328,9 @@ class ApprovalViewSet(viewsets.ModelViewSet):
         elif is_customer(self.request):
             user_orgs = [
                 org.id for org in self.request.user.leaseslicensing_organisations.all()
-            ]
+            ] if hasattr(self.request.user, "leaseslicensing_organisations") else []
             queryset = Approval.objects.filter(
-                Q(org_applicant_id__in=user_orgs) | Q(submitter=self.request.user)
+                Q(org_applicant_id__in=user_orgs) | Q(submitter=self.request.user.id)
             )
             return queryset
         return Approval.objects.none()

--- a/leaseslicensing/components/compliances/email.py
+++ b/leaseslicensing/components/compliances/email.py
@@ -300,15 +300,16 @@ def send_compliance_accept_email_notification(compliance, request, is_test=False
 
     context = {"compliance": compliance}
     submitter = (
-        compliance.submitter.email
-        if compliance.submitter and compliance.submitter.email
-        else compliance.proposal.submitter.email
+        retrieve_email_user(compliance.submitter).email
+        if compliance.submitter and retrieve_email_user(compliance.submitter).email
+        else retrieve_email_user(compliance.proposal.submitter).email
     )
     all_ccs = []
     if compliance.proposal.org_applicant and compliance.proposal.org_applicant.email:
         cc_list = compliance.proposal.org_applicant.email
         if cc_list:
             all_ccs = [cc_list]
+    # TODO `leaseslicensing/components/emails/templates/leaseslicensing/emails/base_email.txt` misses body text
     msg = email.send(submitter, cc=all_ccs, context=context)
     if is_test:
         return
@@ -320,9 +321,12 @@ def send_compliance_accept_email_notification(compliance, request, is_test=False
             msg, compliance.proposal.org_applicant, compliance.submitter, sender=sender
         )
     else:
-        _log_user_email(
-            msg, compliance.proposal.submitter, compliance.submitter, sender=sender
-        )
+        try:
+            _log_user_email(
+                msg, compliance.proposal.submitter, compliance.submitter, sender=sender
+            )
+        except:
+            pass
 
 
 def send_external_submit_email_notification(request, compliance, is_test=False):
@@ -583,7 +587,9 @@ def _log_org_email(email_message, organisation, customer, sender=None):
     return email_entry
 
 
-#def _log_user_email(email_message, emailuser, customer, sender=None):
+def _log_user_email(email_message, emailuser, customer, sender=None):
+    # TODO Function definition is commented out. Probably needs implementation of `EmailUserLogEntry` in `ledger_api_client.ledger_models`?
+    raise NotImplementedError("`_log_user_email` has been commented out. Needs implementation.")
 #    from ledger.accounts.models import EmailUserLogEntry
 #
 #    if isinstance(

--- a/leaseslicensing/components/invoicing/serializers.py
+++ b/leaseslicensing/components/invoicing/serializers.py
@@ -168,6 +168,9 @@ class InvoicingDetailsSerializer(serializers.ModelSerializer):
             # When "Complete Editing" clicked
             charge_method = attrs.get('charge_method')
 
+            if not charge_method:
+                raise serializers.ValidationError(["No charge method selected"])
+
             if charge_method.key == settings.CHARGE_METHOD_ONCE_OFF_CHARGE:
                 self.set_default_values(attrs, [
                     'charge_method',

--- a/leaseslicensing/components/proposals/models.py
+++ b/leaseslicensing/components/proposals/models.py
@@ -1195,13 +1195,12 @@ class Proposal(DirtyFieldsMixin, models.Model):
 
     # Append 'P' to Proposal id to generate Lodgement number. Lodgement number and lodgement sequence are used to generate Reference.
     def save(self, *args, **kwargs):
-        # super(Proposal, self).save(*args, **kwargs)
+        super(Proposal, self).save(*args, **kwargs) # Call parent `save` to create a Proposal id
 
         if self.lodgement_number == "":
             new_lodgment_id = "A{0:06d}".format(self.pk)
             self.lodgement_number = new_lodgment_id
-            # self.save()
-        super(Proposal, self).save(*args, **kwargs)
+            self.save()
 
     @property
     def relevant_applicant(self):

--- a/leaseslicensing/frontend/leaseslicensing/src/components/common/submission.vue
+++ b/leaseslicensing/frontend/leaseslicensing/src/components/common/submission.vue
@@ -13,7 +13,7 @@
                     </div>
                     <div class="col-sm-12 top-buffer-s">
                         <strong>Lodged on</strong><br/>
-                        {{ lodgement_date | formatDate}}
+                        {{ formatDate(lodgement_date) }}
                     </div>
                     <div class="col-sm-12 top-buffer-s">
                         <table class="table small-table">
@@ -53,7 +53,7 @@ export default {
             default: null,
         },
     },
-    filters: {
+    methods: {
         formatDate: function(data){
             return data ? moment(data).format('DD/MM/YYYY HH:mm:ss'): '';
         }

--- a/leaseslicensing/frontend/leaseslicensing/src/components/common/table_approvals.vue
+++ b/leaseslicensing/frontend/leaseslicensing/src/components/common/table_approvals.vue
@@ -352,6 +352,8 @@ export default {
                                     } else if(full.amend_or_renew === 'renew' || vm.debug){
                                         links +=  `<a href='#${full.id}' data-renew-approval='${full.current_proposal_id}'>Renew</a><br/>`;
                                     }
+                                    // Links to `external/approvals/approval.vue`
+                                    links +=  `<a href='/external/approval/${full.id}'>View</a><br/>`;
                                     links +=  `<a href='#${full.id}' data-surrender-approval='${full.id}'>Surrender</a><br/>`;
                                 }
 

--- a/leaseslicensing/frontend/leaseslicensing/src/components/common/table_compliances.vue
+++ b/leaseslicensing/frontend/leaseslicensing/src/components/common/table_compliances.vue
@@ -292,6 +292,7 @@ export default {
                                 }
                             }
                             else{
+                                // FIXME If checked for `can_user_view` first an already submitted Compliance can potentially be submitted again and again
                                 if (full.can_user_view) {
                                     links +=  `<a href='/external/compliance/${full.id}'>View</a><br/>`;
 

--- a/leaseslicensing/frontend/leaseslicensing/src/components/common/table_proposals.vue
+++ b/leaseslicensing/frontend/leaseslicensing/src/components/common/table_proposals.vue
@@ -507,26 +507,27 @@ export default {
         },
         discardProposal: function(proposal_id) {
             let vm = this;
-            swal({
+            swal.fire({
                 title: "Discard Application",
                 text: "Are you sure you want to discard this application?",
-                type: "warning",
+                icon: "warning",
                 showCancelButton: true,
                 confirmButtonText: 'Discard Application',
                 confirmButtonColor:'#dc3545'
-            }).then(() => {
-                fetch(api_endpoints.discard_proposal(proposal_id), { method: 'DELETE', })
-                .then((response) => {
-                    swal(
-                        'Discarded',
-                        'Your application has been discarded',
-                        'success'
-                    )
-                    //vm.$refs.application_datatable.vmDataTable.ajax.reload();
-                    vm.$refs.application_datatable.vmDataTable.draw();
-                }, (error) => {
+            }).then(async result => {
+                if (result.isConfirmed) {
+                    fetch(api_endpoints.discard_proposal(proposal_id), { method: 'DELETE', })
+                    .then((response) => {
+                        swal.fire(
+                            'Discarded',
+                            'Your application has been discarded',
+                            'success'
+                        )
+                        //vm.$refs.application_datatable.vmDataTable.ajax.reload();
+                        vm.$refs.application_datatable.vmDataTable.draw();
+                    }, (error) => {
                 });
-            },(error) => {
+            }},(error) => {
 
             });
         },

--- a/leaseslicensing/frontend/leaseslicensing/src/components/external/approvals/approval.vue
+++ b/leaseslicensing/frontend/leaseslicensing/src/components/external/approvals/approval.vue
@@ -1,0 +1,49 @@
+<template>
+<!-- External Proposal view -->
+
+<h3>{{ approval.lodgement_number }}</h3>
+
+<div>Issue date: {{ approval.issue_date }}</div>
+<div>Commencement: {{ approval.start_date }}</div>
+<div>Expiry: {{ approval.expiry_date }}</div>
+
+</template>
+
+<script>
+import { api_endpoints, helpers } from '@/utils/hooks'
+
+export default {
+    name: 'ExternalApprovalDetail',
+    data() {
+        let vm = this;
+        vm._uid = vm._.uid; // Vue3
+        return {
+            approval: {
+                applicant_id: null
+            },
+        }
+    },
+    props: {
+        approvalId: {
+            type: Number,
+        },
+    },
+    created: async function() {
+        await fetch(helpers.add_endpoint_json(api_endpoints.approvals, this.$route.params.approval_id)).then(async response => {
+            if (!response.ok) {
+                return await response.json().then(json => { throw new Error(json); });
+            } else {
+                return await response.json();
+                }
+            })
+            .then (data => {
+                this.approval = Object.assign({}, data);
+                this.approval.applicant_id = data.applicant_id;
+            })
+            .catch(error => {
+                console.log(`Error fetching external approval data ${error}`);
+            })
+        this;
+    }
+}
+</script>

--- a/leaseslicensing/frontend/leaseslicensing/src/components/external/proposal.vue
+++ b/leaseslicensing/frontend/leaseslicensing/src/components/external/proposal.vue
@@ -527,62 +527,68 @@ export default {
         this.submitting = true;
         this.paySubmitting=true;
 
-        try {
-            await swal.fire({
+        swal.fire({
                 title: this.submitText + " Application",
                 text: "Are you sure you want to " + this.submitText.toLowerCase()+ " this application?",
                 icon: "question",
                 showCancelButton: true,
                 confirmButtonText: this.submitText
-            })
-        } catch (cancel) {
-            this.submitting = false;
-            this.paySubmitting=false;
-            return;
-        }
-        try {
-            //const res = await this.save(false, this.proposal_submit_url);
-            await this.save(false, this.proposal_submit_url);
-            this.$nextTick(() => {
-                const lodgementDate = new Date(this.proposal.lodgement_date)
-                this.$router.push({
-                    name: 'submit-proposal',
+            }).then(async result => {
+                if (!result.isConfirmed) {
+                  // Cancel
+                  this.submitting = false;
+                  this.paySubmitting=false;
+                  return;
+                } else {
+                  // Accept
+                  try {
+                    //const res = await this.save(false, this.proposal_submit_url);
+                    await this.save(false, this.proposal_submit_url);
+                    this.$nextTick(() => {
+                        const lodgementDate = new Date(this.proposal.lodgement_date)
+                        this.$router.push({
+                            name: 'submit-proposal',
+                            /*
+                            params: {
+                                proposal_id: this.proposal,
+                            },
+                            */
+                            params: this.proposal,
+                            //query: this.proposal,
+                            /*
+                            meta: {
+                                proposal_id: this.proposal.id,
+                                lodgement_number: this.proposal.lodgement_number,
+                                lodgement_date: lodgementDate.toLocaleDateString("en-AU"),
+                                application_type_text: this.proposal.application_type.confirmation_text
+                            },
+                            */
+                        });
+                    })
                     /*
-                    params: {
-                        proposal_id: this.proposal,
-                    },
+                    if (res.ok) {
+                        // change this to confirmation page
+                        this.$router.push({
+                            name: 'submit-proposal',
+                            params: {proposal: this.proposal},
+                        });
+                    }
                     */
-                    params: this.proposal,
-                    //query: this.proposal,
-                    /*
-                    meta: {
-                        proposal_id: this.proposal.id,
-                        lodgement_number: this.proposal.lodgement_number,
-                        lodgement_date: lodgementDate.toLocaleDateString("en-AU"),
-                        application_type_text: this.proposal.application_type.confirmation_text
-                    },
-                    */
-                });
-            })
-            /*
-            if (res.ok) {
-                // change this to confirmation page
-                this.$router.push({
-                    name: 'submit-proposal',
-                    params: {proposal: this.proposal},
-                });
-            }
-            */
-        } catch(err) {
-            console.log(err)
-            await swal.fire({
-                title: 'Submit Error',
-                html: helpers.apiVueResourceError(err),
-                icon: 'error',
-            })
-            this.savingProposal = false;
-            this.paySubmitting = false;
-        }
+                  } catch(err) {
+                      console.log(err)
+                      await swal.fire({
+                          title: 'Submit Error',
+                          html: helpers.apiVueResourceError(err),
+                          icon: 'error',
+                      })
+                      this.savingProposal = false;
+                      this.paySubmitting = false;
+                  }
+                }
+          },(error) => {
+
+            });
+
         /*
         if (!this.proposal.fee_paid) {
             this.$nextTick(async () => {

--- a/leaseslicensing/frontend/leaseslicensing/src/components/external/routes/index.js
+++ b/leaseslicensing/frontend/leaseslicensing/src/components/external/routes/index.js
@@ -6,6 +6,7 @@ import ProposalSubmit from '@/components/external/proposal_submit.vue'
 import Organisation from '@/components/external/organisations/manage.vue'
 import Compliance from '../compliances/access.vue'
 import ComplianceSubmit from '../compliances/submit.vue'
+import Approval from '../approvals/approval.vue'
 /*
 import Compliance from '../compliances/access.vue'
 import ComplianceSubmit from '../compliances/submit.vue'
@@ -21,6 +22,11 @@ export default
             path: '/external/',
             component: ExternalDashboard,
             name: 'external-dashboard'
+        },
+        {
+            path: 'approval/:approval_id',
+            component: Approval,
+            name: 'external-approval-detail',
         },
         {
             path: 'organisations/manage/:org_id',

--- a/leaseslicensing/frontend/leaseslicensing/src/components/form_lease_licence.vue
+++ b/leaseslicensing/frontend/leaseslicensing/src/components/form_lease_licence.vue
@@ -347,7 +347,7 @@
         <div class="col-sm-12 inline-details-text">
             <div class="row question-row">
             <div class="col-sm-3">
-                <label for="legislative_requirements_text" class="control-label pull-left">If legislative or regulatory requirements apply to thie proposal, please provide details and upload any approvals already received</label>
+                <label for="legislative_requirements_text" class="control-label pull-left">If legislative or regulatory requirements apply to the proposal, please provide details and upload any approvals already received</label>
             </div>
             <div class="col-sm-8">
                 <RichText

--- a/leaseslicensing/frontend/leaseslicensing/src/components/internal/approvals/approval.vue
+++ b/leaseslicensing/frontend/leaseslicensing/src/components/internal/approvals/approval.vue
@@ -14,7 +14,7 @@
 
                             <div class="col-sm-12 top-buffer-s">
                                 <strong>Issued on</strong><br/>
-                                {{ approval.issue_date | formatDate}}
+                                {{ formatDate(approval.issue_date) }}
                             </div>
                             <div class="col-sm-12 top-buffer-s">
                                 <table class="table small-table">
@@ -61,42 +61,38 @@
 
             <div class="row">
 
-                <div class="card card-default">
-                  <div class="card-header">
-                      <h3 class="card-title">{{ approvalLabel }}
-                        <a class="panelClicker" :href="'#'+oBody" data-toggle="collapse" expanded="true"  data-parent="#userInfo" :aria-controls="oBody">
-                            <span class="glyphicon glyphicon-chevron-down pull-right "></span>
-                        </a>
-                    </h3>
-                  </div>
-                  <div v-if="loading.length == 0" class="card-body collapse" :id="oBody">
+                <FormSection :formCollapse="false" label="License" Index="oBody">
+                    <!-- <CollapsibleFilters component_title="Assessor comments" ref="collapsible_filters" @created="collapsible_component_mounted" class="mb-2">
+                    </CollapsibleFilters> -->
+
+                    <div v-if="loading.length == 0" class="card-body" :id="oBody">
                       <form class="form-horizontal" action="index.html" method="post">
-                          <div v-if="mooringLicence" class="form-group">
+                          <div v-if="mooringLicence" class="row mb-3">
                             <label for="" class="col-sm-3 control-label">Mooring</label>
                             <div class="col-sm-6">
-                                <label for="" class="control-label pull-left">{{approval.mooring_licence_mooring}}</label>
+                                <textarea disabled class="form-control" name="mooring" rows="1" placeholder="" style="resize: none">{{approval.mooring_licence_mooring}}</textarea>
                             </div>
                           </div>
-                          <div class="form-group">
-                            <label for="" class="col-sm-3 control-label">Issue Date</label>
+                          <div class="row mb-3">
+                            <label for="issue_date" class="col-sm-3 control-label">Issue Date</label>
                             <div class="col-sm-6">
-                                <label for="" class="control-label pull-left">{{approval.issue_date | formatDate}}</label>
+                                <textarea disabled id="issue_date" class="form-control" name="issue_date" rows="1" placeholder="" style="resize: none">{{ formatDate(approval.issue_date) }}</textarea>
                             </div>
                           </div>
-                          <div class="form-group">
-                            <label for="" class="col-sm-3 control-label" >Start Date</label>
+                          <div class="row mb-3">
+                            <label for="start_date" class="col-sm-3 control-label" >Start Date</label>
                             <div class="col-sm-6">
-                                <label for="" class="control-label pull-left">{{approval.start_date | formatDate}}</label>
+                                <textarea disabled id="issue_date" class="form-control" name="start_date" rows="1" placeholder="" style="resize: none">{{ formatDate(approval.start_date) }}</textarea>
                             </div>
                           </div>
-                          <div class="form-group">
-                            <label for="" class="col-sm-3 control-label">Expiry Date</label>
-                            <div class="col-sm-3">
-                                <label for="" class="control-label pull-left">{{approval.expiry_date_str}}</label>
+                          <div class="row mb-3">
+                            <label for="expiry_date" class="col-sm-3 control-label">Expiry Date</label>
+                            <div class="col-sm-6">
+                                <textarea disabled id="issue_date" class="form-control" name="expiry_date" rows="1" placeholder="" style="resize: none">{{ formatDate(approval.expiry_date) }}</textarea>
                             </div>
 
                           </div>
-                          <div class="form-group">
+                          <div class="row mb-3">
                               <label for="" class="col-sm-3 control-label" >{{ approvalLabel }}</label>
                             <div class="col-sm-4">
                                 <!-- <p><a target="_blank" :href="approval.licence_document" class="control-label pull-left">Approval.pdf</a></p> -->
@@ -114,9 +110,9 @@
                           </div-->
                        </form>
                   </div>
-                </div>
-            </div>
+                </FormSection>
 
+            </div>
         </div>
     </div>
 </div>
@@ -133,9 +129,10 @@ import { api_endpoints, helpers } from '@/utils/hooks'
 //import ComponentSiteSelection from '@/components/common/apiary/component_site_selection.vue'
 //import SectionAnnualRentalFee from '@/components/common/apiary/section_annual_rental_fee.vue'
 export default {
-  name: 'ApprovalDetail',
-  data() {
+    name: 'ApprovalDetail',
+    data() {
     let vm = this;
+    vm._uid = vm._.uid; // Vue3
     return {
         showExpired: false,
         moorings_datatable_id: 'moorings-datatable-' + vm._uid,
@@ -272,11 +269,6 @@ export default {
           });
       },
   },
-  filters: {
-    formatDate: function(data){
-        return moment(data).format('DD/MM/YYYY');
-    }
-  },
     props: {
         approvalId: {
             type: Number,
@@ -289,7 +281,7 @@ export default {
       console.log({resData})
       //this.approval = Object.assign({}, response.body);
       this.approval = Object.assign({}, resData);
-      this.approval.applicant_id = response.body.applicant_id;
+      this.approval.applicant_id = resData.applicant_id;
       if (this.approval.submitter.postal_address == null){ this.approval.submitter.postal_address = {}; }
       await this.$nextTick(() => {
           if (this.approval && this.approval.id && this.authorisedUserPermit) {
@@ -315,6 +307,8 @@ export default {
         let description = '';
         if (this.approval && this.approval.approval_type_dict) {
             description = this.approval.approval_type_dict.description;
+        } else {
+            description = "License"
         }
         return description;
     },
@@ -342,6 +336,9 @@ export default {
 
   },
   methods: {
+    formatDate: function(data){
+        return data? moment(data).format(this.DATE_TIME_FORMAT): '';
+    },
     constructMooringsTable: function() {
         let vm = this;
         this.$refs.moorings_datatable.vmDataTable.clear().draw();

--- a/leaseslicensing/frontend/leaseslicensing/src/components/internal/approvals/approval_history.vue
+++ b/leaseslicensing/frontend/leaseslicensing/src/components/internal/approvals/approval_history.vue
@@ -298,7 +298,7 @@ export default {
             //this.validation_form.resetForm();
         },
         fetchApprovalDetails: async function() {
-            const res = await this.$http.get(api_endpoints.lookupApprovalDetails(this.approvalId));
+            const res = await fetch(api_endpoints.lookupApprovalDetails(this.approvalId) );
             if (res.ok) {
                 this.approvalDetails = Object.assign({}, res.body);
             }

--- a/leaseslicensing/frontend/leaseslicensing/src/components/internal/competitive_process/competitive_process.vue
+++ b/leaseslicensing/frontend/leaseslicensing/src/components/internal/competitive_process/competitive_process.vue
@@ -469,19 +469,29 @@ export default {
         assignRequestUser: async function(){
             let vm = this
             console.log('in assignRequestUser')
-            try {
-                const response = await fetch(helpers.add_endpoint_json(api_endpoints.competitive_process, (vm.competitive_process.id + '/assign_request_user')))
-                const resData = await response.json();
-                this.competitive_process = Object.assign({}, resData);
+
+            fetch(helpers.add_endpoint_json(api_endpoints.competitive_process, (vm.competitive_process.id + '/assign_request_user'))).then(async response => {
+            if (!response.ok) {
+                // const text = response.text();
+                // throw new Error(text);
+                return response.text().then(text => { throw new Error(text) });
+            } else {
+                return await response.json();
+                }
+            })
+            .then (data => {
+                vm.competitive_process = Object.assign({}, resData);
+                vm.updateAssignedOfficerSelect();
+            })
+            .catch(error => {
                 this.updateAssignedOfficerSelect();
-            } catch (error) {
-                this.updateAssignedOfficerSelect();
-                swal.fire(
-                    'Proposal Error',
-                    helpers.apiVueResourceError(error),
-                    'error'
-                )
-            }
+                console.log(error);
+                swal.fire({
+                    title: 'Proposal Error',
+                    text: error,
+                    icon: 'error'
+                })
+            })
         },
         fetchCompetitiveProcess: async function(){
             let vm = this
@@ -496,7 +506,19 @@ export default {
             } finally {
 
             }
-        }
+        },
+        updateAssignedOfficerSelect:function(){
+            // FIXME not sure if adding this function here is the correct way of doing it
+            console.log('updateAssignedOfficerSelect')
+            let vm = this;
+            if (vm.competitive_process.status === 'in_progress'){
+                vm.$refs.workflow.updateAssignedOfficerSelect(vm.competitive_process.accessing_user.id)
+            }
+            else{
+                // ...
+                vm.$refs.workflow.updateAssignedOfficerSelect(vm.competitive_process.accessing_user.id)
+            }
+        },
     }
 }
 </script>

--- a/leaseslicensing/frontend/leaseslicensing/src/components/internal/compliances/access.vue
+++ b/leaseslicensing/frontend/leaseslicensing/src/components/internal/compliances/access.vue
@@ -139,17 +139,37 @@ export default {
           console.log(moment(data).format('DD/MM/YYYY'));
       },
   },
-  beforeRouteEnter: async function(to, from, next){
-      /*
-    const res = await fetch(`/api/proposal/${this.$route.params.proposal_id}/internal_proposal.json`);
-    const resData = await res.json();
-      this.compliance = Object.assign({}, resData);
-    */
-      next(async (vm) => {
-          const url = helpers.add_endpoint_json(api_endpoints.compliances,to.params.compliance_id+'/internal_compliance');
-          vm.compliance = Object.assign({}, await helpers.fetchWrapper(url));
-          vm.members = vm.compliance.allowed_assessors;
-      });
+//   beforeRouteEnter: async function(to, from, next){
+    beforeRouteEnter: function(to, from, next){
+        /*
+        const res = await fetch(`/api/proposal/${this.$route.params.proposal_id}/internal_proposal.json`);
+        const resData = await res.json();
+        this.compliance = Object.assign({}, resData);
+        */
+
+        const url = helpers.add_endpoint_json(api_endpoints.compliances,to.params.compliance_id+'/internal_compliance');
+        fetch(helpers.add_endpoint_json(api_endpoints.compliances,to.params.compliance_id+'/internal_compliance')).then(async response => {
+            if (!response.ok) {
+                return await response.text().then(text => { throw new Error(text); });
+            } else {
+                return await response.json();
+                }
+            })
+            .then (async data => {
+                next((vm) => {
+                    // const data = await response.json();
+                    vm.compliance = Object.assign({}, data);
+                    vm.members = vm.compliance.allowed_assessors;
+                });
+            })
+            .catch(error => {
+                console.log(error);
+                swal.fire({
+                    title: 'Proposal Error',
+                    text: error,
+                    icon: 'error'
+                })
+            });
   },
   components: {
     datatable,
@@ -213,11 +233,12 @@ export default {
         }
     },
     acceptCompliance: async function() {
-        await new swal({
+        let vm = this;
+        await swal.fire({
         //swal({
             title: "Accept Compliance with requirements",
             text: "Are you sure you want to accept this compliance with requirements?",
-            type: "question",
+            icon: "question",
             showCancelButton: true,
             confirmButtonText: 'Accept'
         });

--- a/leaseslicensing/frontend/leaseslicensing/src/components/internal/proposals/proposal.vue
+++ b/leaseslicensing/frontend/leaseslicensing/src/components/internal/proposals/proposal.vue
@@ -2,7 +2,7 @@
     <div v-if="proposal" class="container" id="internalProposal">
         <div v-if="debug">internal/proposals/proposal.vue</div>
         <div class="row">
-            <h3>{{ proposal.lodgement_number }} - {{ proposal.application_type.name_display }} - {{ proposal.proposal_type.description }}</h3>
+            <h3>{{ proposal.lodgement_number }} - {{ proposal.application_type? proposal.application_type.name_display: null }} - {{ proposal.proposal_type? proposal.proposal_type.description: null }}</h3>
 
             <div class="col-md-3">
                 <CommsLogs
@@ -330,7 +330,7 @@
             ref="proposed_approval"
             :processing_status="proposal.processing_status"
             :proposal_id="proposal.id"
-            :proposal_type='proposal.proposal_type.code'
+            :proposal_type="proposal.proposal_type? proposal.proposal_type.code: null"
             :isApprovalLevelDocument="isApprovalLevelDocument"
             :submitter_email="submitter_email"
             :applicant_email="applicant_email"
@@ -391,13 +391,13 @@ export default {
     data: function() {
         let vm = this;
         return {
-            detailsBody: 'detailsBody'+vm._uid,
-            addressBody: 'addressBody'+vm._uid,
-            contactsBody: 'contactsBody'+vm._uid,
-            siteLocations: 'siteLocations'+vm._uid,
-            related_items_datatable_id: 'related_items_datatable' + vm._uid,
+            detailsBody: 'detailsBody'+vm._.uid,
+            addressBody: 'addressBody'+vm._.uid,
+            contactsBody: 'contactsBody'+vm._.uid,
+            siteLocations: 'siteLocations'+vm._.uid,
+            related_items_datatable_id: 'related_items_datatable' + vm._.uid,
             defaultKey: "aho",
-            "proposal": null,
+            proposal: null,
             assessment: {},
             "loading": [],
             //selected_referral: '',
@@ -413,7 +413,7 @@ export default {
             hasAmendmentRequest: false,
             //requirementsComplete:true,
             state_options: ['requirements','processing'],
-            contacts_table_id: vm._uid+'contacts-table',
+            contacts_table_id: vm._.uid+'contacts-table',
             contacts_options:{
                 language: {
                     processing: "<i class='fa fa-4x fa-spinner fa-spin'></i>"
@@ -877,16 +877,22 @@ export default {
             const res = await fetch('/api/proposal/' + this.proposal.id + '/finance_complete_editing.json', { body: JSON.stringify(payload), method: 'POST' })
 
             if(res.ok){
-                await new swal({
+                await swal.fire({
                     title: 'Saved',
                     text: 'Your proposal has been saved',
-                    type: 'success',
+                    icon: 'success',
                 })
             } else {
-                await new swal({
-                    title: "Please fix following errors before saving",
-                    text: await res.json(),
-                    type:'error',
+                let errors = [];
+                await res.json().then(json => {
+                    for (var key in json) {
+                        errors.push(`${key}: ${json[key].join(",")}`)
+                    }
+                    swal.fire({
+                        title: "Please fix following errors before saving",
+                        text: errors.join(","),
+                        icon:'error',
+                    })
                 })
             }
         },
@@ -1189,19 +1195,27 @@ export default {
         assignRequestUser: async function(){
             let vm = this
             console.log('in assignRequestUser')
-            try {
-                const response = await fetch(helpers.add_endpoint_json(api_endpoints.proposal, (vm.proposal.id + '/assign_request_user')))
-                const resData = await response.json();
-                this.proposal = Object.assign({}, resData);
+
+            fetch(helpers.add_endpoint_json(api_endpoints.proposal, (vm.proposal.id + '/assign_request_user'))).then(async response => {
+            if (!response.ok) {
+                return await response.json().then(json => { throw new Error(json); });
+            } else {
+                return await response.json();
+                }
+            })
+            .then (data => {
+                vm.proposal = Object.assign({}, data);
+                vm.updateAssignedOfficerSelect();
+            })
+            .catch(error => {
                 this.updateAssignedOfficerSelect();
-            } catch (error) {
-                this.updateAssignedOfficerSelect();
-                swal.fire(
-                    'Proposal Error',
-                    helpers.apiVueResourceError(error),
-                    'error'
-                )
-            }
+                console.log(error);
+                swal.fire({
+                    title: 'Proposal Error',
+                    text: error,
+                    icon: 'error'
+                })
+            })
         },
         /*
         refreshFromResponse:function(response){
@@ -1431,16 +1445,24 @@ export default {
             }
         });
     },
-    created: async function() {
+    created: function() {
+        let vm = this;
         console.log('in created')
-        try {
-            const res = await fetch(`/api/proposal/${this.$route.params.proposal_id}/internal_proposal.json`);
-            const resData = await res.json();
-            this.proposal = Object.assign({}, resData);
-            this.hasAmendmentRequest=this.proposal.hasAmendmentRequest;
-        } catch (err) {
-          console.log(err);
-        }
+        fetch(`/api/proposal/${this.$route.params.proposal_id}/internal_proposal.json`).then(async response => {
+            if (!response.ok) {
+                const text = await response.json();
+                throw new Error(text);
+            } else {
+                return await response.json();
+            }
+        })
+        .then (data => {
+            vm.proposal = Object.assign({}, data);
+            vm.hasAmendmentRequest=this.proposal.hasAmendmentRequest;
+        })
+        .catch(error => {
+            console.log(error);
+        })
     },
 }
 </script>

--- a/leaseslicensing/frontend/leaseslicensing/src/components/internal/proposals/proposal.vue
+++ b/leaseslicensing/frontend/leaseslicensing/src/components/internal/proposals/proposal.vue
@@ -886,7 +886,7 @@ export default {
                 let errors = [];
                 await res.json().then(json => {
                     for (var key in json) {
-                        errors.push(`${key}: ${json[key].join(",")}`)
+                        errors.push(`${key}: ${typeof(json[key])=='string'? json[key]: json[key].join(",")}`)
                     }
                     swal.fire({
                         title: "Please fix following errors before saving",

--- a/leaseslicensing/frontend/leaseslicensing/src/components/internal/proposals/proposal_approval.vue
+++ b/leaseslicensing/frontend/leaseslicensing/src/components/internal/proposals/proposal_approval.vue
@@ -54,8 +54,8 @@
                 :processing_status="proposal.processing_status"
                 :proposal_id="proposal.id"
                 :proposal_type='proposal.proposal_type.code'
-                :submitter_email="submitter_email"
-                :applicant_email="applicant_email"
+                :submitter_email="proposal.submitter.email"
+                :applicant_email="proposal.applicant"
                 :key="proposedApprovalKey"
                 :proposedApprovalKey="proposedApprovalKey"
                 :proposedApprovalState="proposedApprovalState"
@@ -88,13 +88,15 @@ import InvoicingDetails from "@/components/common/invoicing_details.vue"
 export default {
     name: 'InternalProposalApproval',
     props: {
-        proposal: Object
+        proposal: Object,
+        proposedApprovalState: "",
+        proposedApprovalKey: null
     },
     data: function() {
         let vm = this;
         return {
-            proposedDecision: "proposal-decision-"+vm._uid,
-            proposedLevel: "proposal-level-"+vm._uid,
+            proposedDecision: "proposal-decision-"+vm._.uid,
+            proposedLevel: "proposal-level-"+vm._.uid,
             uploadedFile: null,
             component_site_selection_key: '',
         }

--- a/leaseslicensing/frontend/leaseslicensing/src/components/internal/proposals/proposed_issuance.vue
+++ b/leaseslicensing/frontend/leaseslicensing/src/components/internal/proposals/proposed_issuance.vue
@@ -7,7 +7,7 @@
                 ref="proposed_approval_form"
                 :processing_status="proposal.processing_status"
                 :proposal_id="proposal.id"
-                :proposal_type='proposal.proposal_type.code'
+                :proposal_type="proposal.proposal_type? proposal.proposal_type.code: null"
                 :submitter_email="submitter_email"
                 :applicant_email="applicant_email"
                 :key="proposedApprovalKey"
@@ -48,14 +48,14 @@ export default {
             type: String,
             required: true
         },
-        submitter_email: {
-            type: String,
-            required: true
-        },
-        applicant_email: {
-            type: String,
-            //default: ''
-        },
+        // submitter_email: {
+        //     type: String,
+        //     required: true
+        // },
+        // applicant_email: {
+        //     type: String,
+        //     //default: ''
+        // },
         proposedApprovalKey: {
             type: String,
             //default: ''

--- a/leaseslicensing/frontend/leaseslicensing/src/components/internal/proposals/proposed_issuance_form.vue
+++ b/leaseslicensing/frontend/leaseslicensing/src/components/internal/proposals/proposed_issuance_form.vue
@@ -304,10 +304,10 @@ export default {
             type: String,
             required: true
         },
-        isApprovalLevelDocument: {
-            type: Boolean,
-            required: true
-        },
+        // isApprovalLevelDocument: {
+        //     type: Boolean,
+        //     required: true
+        // },
         readonly: {
             type: Boolean,
             required: false
@@ -332,10 +332,10 @@ export default {
             type: Object,
             required: true,
         },
-        assessment: {
-            type: Object,
-            required: true,
-        },
+        // assessment: {
+        //     type: Object,
+        //     required: true,
+        // },
     },
     data:function () {
         return {
@@ -344,7 +344,7 @@ export default {
             form:null,
             approval: {},
             approvalTypes: [],
-            //selectedApprovalType: {},
+            selectedApprovalType: {},
             selectedApprovalTypeId: null,
             // Document Types arrays rely on selectedApprovalTypeId
             availableDocumentTypes: [],
@@ -456,7 +456,7 @@ export default {
             this.updateSelectedApprovalType(id);
         },
         updateSelectedApprovalType(id) {
-            console.log(id);
+            // console.log(id);
             // clear existing doc arrays
             this.availableDocumentTypes = [];
             this.selectedDocumentTypes = [];


### PR DESCRIPTION
Restores working steps from creating a New Application to displaying a very basic View of the approved application in the License dashboard.
- added new very basic external/approvals/approval.vue
- added external approval detail to external/index.js
- added link to approval to external license dashboard
- added call to submit to compliance api
- added error handling to missing invoice setting when completing a license
- some migration of statements to vue3
- added proper error handling to some swal popups and fetch statements
- some formatting of internal approval view
- fixed vue warnings about missing properties


